### PR TITLE
Fixed Instance Profile Role error

### DIFF
--- a/instance_profile/main.tf
+++ b/instance_profile/main.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_instance_profile" "profile" {
   name  = "profile_${var.project}_${var.environment}_${var.function}"
-  roles = [aws_iam_role.role.name]
+  role = aws_iam_role.role.name
 }
 
 resource "aws_iam_role_policy" "policy" {


### PR DESCRIPTION
We are getting this error while running terraform plan on lab/iam

```(and 5 more similar warnings elsewhere)


Error: Unsupported argument

  on .terraform/modules/bastion_instance_profile/instance_profile/main.tf line 3, in resource "aws_iam_instance_profile" "profile":
   3:   roles = [aws_iam_role.role.name]

An argument named "roles" is not expected here. Did you mean "role"?


Error: Unsupported argument

  on .terraform/modules/cassandra_instance_profile/instance_profile/main.tf line 3, in resource "aws_iam_instance_profile" "profile":
   3:   roles = [aws_iam_role.role.name]

An argument named "roles" is not expected here. Did you mean "role"?


Error: Unsupported argument

  on .terraform/modules/outgoing_proxy_iam/instance_profile/main.tf line 3, in resource "aws_iam_instance_profile" "profile":
   3:   roles = [aws_iam_role.role.name]

An argument named "roles" is not expected here. Did you mean "role"?


Error: Unsupported argument

  on .terraform/modules/smartcontent_ftp_instance_profile/instance_profile/main.tf line 3, in resource "aws_iam_instance_profile" "profile":
   3:   roles = [aws_iam_role.role.name]

An argument named "roles" is not expected here. Did you mean "role"?


Error: Unsupported argument

  on .terraform/modules/sre_toolbox_instance_profile/instance_profile/main.tf line 3, in resource "aws_iam_instance_profile" "profile":
   3:   roles = [aws_iam_role.role.name]

An argument named "roles" is not expected here. Did you mean "role"?


Error: Unsupported argument

  on .terraform/modules/standard_ec2_instance_profile/instance_profile/main.tf line 3, in resource "aws_iam_instance_profile" "profile":
   3:   roles = [aws_iam_role.role.name]

An argument named "roles" is not expected here. Did you mean "role"?```